### PR TITLE
Update Dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
       with:
@@ -19,7 +19,6 @@ jobs:
           3.1.x
           6.0.x
           7.0.x
-        include-prerelease: true
     - name: Nerdbank.GitVersioning
       uses: dotnet/nbgv@v0.4.0
       with:

--- a/gfs.YamlDotNet.YamlPath.Tests/gfs.YamlDotNet.YamlPath.Tests.csproj
+++ b/gfs.YamlDotNet.YamlPath.Tests/gfs.YamlDotNet.YamlPath.Tests.csproj
@@ -8,11 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-        <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2" />
-        <PackageReference Include="YamlDotNet" Version="12.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.0.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
+        <PackageReference Include="YamlDotNet" Version="12.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/gfs.YamlDotNet.YamlPath.Tests/gfs.YamlDotNet.YamlPath.Tests.csproj
+++ b/gfs.YamlDotNet.YamlPath.Tests/gfs.YamlDotNet.YamlPath.Tests.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net461;net6.0;net7.0;netcoreapp3.1</TargetFrameworks>
         <Nullable>enable</Nullable>
+        <LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>
         <RootNamespace>gfs.YamlDotNet.YamlPath.Tests</RootNamespace>
     </PropertyGroup>

--- a/gfs.YamlDotNet.YamlPath/gfs.YamlDotNet.YamlPath.csproj
+++ b/gfs.YamlDotNet.YamlPath/gfs.YamlDotNet.YamlPath.csproj
@@ -5,7 +5,7 @@
     <PackageProjectUrl>https://github.com/gfs/YamlPathForYamlDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/gfs/YamlPathForYamlDotNet</RepositoryUrl>
     <Description>Adds a Query extension method to YamlNode objects to perform YamlPath queries.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright (c) Gabe Stocco</Copyright>
     <Configurations>Debug;Release</Configurations>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="12.0.*" />
+    <PackageReference Include="YamlDotNet" Version="12.2.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\LICENSE" Pack="true" PackagePath="\"/>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/gfs.YamlDotNet.YamlPath/gfs.YamlDotNet.YamlPath.csproj
+++ b/gfs.YamlDotNet.YamlPath/gfs.YamlDotNet.YamlPath.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="12.2.0" />
+    <PackageReference Include="YamlDotNet" Version="12.2.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Use SourceLink to properly map repo automatically.
Use PackageLicenseReference to simplify license automation.
Add Framework 4.6.1 support to tests.